### PR TITLE
Removes depencency on yml file

### DIFF
--- a/src/DownloadCommand.php
+++ b/src/DownloadCommand.php
@@ -22,9 +22,9 @@ class DownloadCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
 		$this->initializeClient($input->getOption('key'), $input->getOption('secret'));
-
-		$project_id = $this->config['project_id'];
-		if ($input->getOption('project_id')) {
+        
+        $project_id = $input->getOption('project_id')
+	    if (is_null($project_id)) {
 			$project_id = $this->config['project_id'];
 		}
 


### PR DESCRIPTION
The old way required the yml file to contain an empty project_Id. this removes that dependency if you at least add a param. no more notices